### PR TITLE
#29 color picker

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,7 @@ android {
 
 dependencies {
     implementation 'com.simplemobiletools:commons:5.1.4'
+    implementation 'com.divyanshu.colorseekbar:colorseekbar:1.0.2'
     testImplementation 'junit:junit:4.12'
 }
 

--- a/app/src/main/res/layout/activity_customization.xml
+++ b/app/src/main/res/layout/activity_customization.xml
@@ -186,40 +186,10 @@
         </RelativeLayout>
 
         <RelativeLayout
-            android:id="@+id/customization_app_docker_color_holder"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/customization_app_icon_color_holder"
-            android:layout_marginTop="@dimen/medium_margin"
-            android:background="?attr/selectableItemBackground"
-            android:padding="@dimen/activity_margin">
-
-            <com.simplemobiletools.commons.views.MyTextView
-                android:id="@+id/customization_app_docker_color_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_centerVertical="true"
-                android:paddingLeft="@dimen/medium_margin"
-                android:paddingRight="@dimen/medium_margin"
-                android:text="@string/app_docker_color"/>
-
-            <ImageView
-                android:id="@+id/customization_app_docker_color"
-                android:layout_width="@dimen/color_sample_size"
-                android:layout_height="@dimen/color_sample_size"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentRight="true"
-                android:layout_marginEnd="@dimen/medium_margin"
-                android:layout_marginRight="@dimen/medium_margin"
-                android:clickable="false"/>
-
-        </RelativeLayout>
-
-        <RelativeLayout
             android:id="@+id/camera_preview_holder"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/customization_app_docker_color_holder"
+            android:layout_below="@+id/customization_app_icon_color_holder"
             android:layout_marginBottom="@dimen/bigger_margin"
             android:paddingBottom="@dimen/small_margin"
             android:paddingLeft="@dimen/activity_margin"
@@ -237,10 +207,38 @@
         </RelativeLayout>
 
         <RelativeLayout
+            android:id="@+id/customization_app_docker_color_holder"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/camera_preview_holder"
+            android:layout_alignParentStart="true"
+            android:layout_marginTop="-3dp"
+            android:background="?attr/selectableItemBackground"
+            android:padding="@dimen/activity_margin">
+
+            <com.simplemobiletools.commons.views.MyTextView
+                android:id="@+id/customization_app_docker_color_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:paddingLeft="@dimen/medium_margin"
+                android:paddingRight="@dimen/medium_margin"
+                android:text="@string/app_docker_color" />
+
+            <com.divyanshu.colorseekbar.ColorSeekBar
+                android:id="@+id/color_seek_bar"
+                android:layout_width="200dp"
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:layout_marginEnd="33dp" />
+        </RelativeLayout>
+
+        <RelativeLayout
             android:id="@+id/apply_to_all_holder"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/camera_preview_holder"
+            android:layout_below="@+id/customization_app_docker_color_holder"
             android:layout_centerHorizontal="true"
             android:background="?attr/selectableItemBackground">
 


### PR DESCRIPTION
There were some issues adding the color picker component. CustomizationActivity is a read-only file, and thus I was not able to implement the dock color picker the same way as the app icon color picker currently in the app.
The solution I took was to import a color slider. Reference: [https://github.com/divyanshub024/ColorSeekBar?fbclid=IwAR2v_3L6CfeK8n6yExKd3DOIxl3vSiWk2UU6oDi9xxohkYwk5vlJF4yT3vY]
As stated in their readme, the color can be fetched by 
`color_seek_bar.setOnColorChangeListener(object: ColorSeekBar.OnColorChangeListener{
           override fun onColorChangeListener(color: Int) {
               //gives the selected color
               view.setBackgroundColor(color)
           }
       })`
which will be used by the next teammate to continue this feature.
