### PR TITLE
#44 Hotfix API 21 to 23

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId "com.simplemobiletools.camera"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 28
         versionCode 64
         versionName "5.0.0"


### PR DESCRIPTION
Hotfix to get docker foreground working. The version was reverted to 21 for debugging test coverage #74. 